### PR TITLE
Improve support for Pharo 8.0 by backporting TaRenameSlot behavior

### DIFF
--- a/src/BaselineOfTalents/BaselineOfTalents.class.st
+++ b/src/BaselineOfTalents/BaselineOfTalents.class.st
@@ -26,12 +26,12 @@ BaselineOfTalents >> baseline: spec [
 			group: 'test'
 				with: #('Talents-Tests' 'Talents-Pharo8');
 
-			postLoadDoIt: #'postload:package:'
+			preLoadDoIt: #'preload:package:'
 	]
 ]
 
 { #category : #actions }
-BaselineOfTalents >> postload: loader package: packageSpec [
+BaselineOfTalents >> preload: loader package: packageSpec [
 
 	"Add missing instance variable, required for extension method behavior."
 

--- a/src/BaselineOfTalents/BaselineOfTalents.class.st
+++ b/src/BaselineOfTalents/BaselineOfTalents.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #BaselineOfTalents,
 	#superclass : #BaselineOf,
-	#category : 'BaselineOfTalents'
+	#category : #BaselineOfTalents
 }
 
 { #category : #baselines }
@@ -15,5 +15,15 @@ BaselineOfTalents >> baseline: spec [
 			with: #(Talents);
 		group: 'test'
 			with: #('Talents-Tests')
+	].
+	spec
+		for: #'pharo8.x'
+		do: [ spec
+			package: 'Talents-Pharo8' with: [ spec requires: #('Talents') ];
+
+			group: 'core'
+				with: #('Talents-Pharo8');
+			group: 'test'
+				with: #('Talents-Tests' 'Talents-Pharo8')
 	]
 ]

--- a/src/BaselineOfTalents/BaselineOfTalents.class.st
+++ b/src/BaselineOfTalents/BaselineOfTalents.class.st
@@ -24,6 +24,16 @@ BaselineOfTalents >> baseline: spec [
 			group: 'core'
 				with: #('Talents-Pharo8');
 			group: 'test'
-				with: #('Talents-Tests' 'Talents-Pharo8')
+				with: #('Talents-Tests' 'Talents-Pharo8');
+
+			postLoadDoIt: #'postload:package:'
 	]
+]
+
+{ #category : #actions }
+BaselineOfTalents >> postload: loader package: packageSpec [
+
+	"Add missing instance variable, required for extension method behavior."
+
+	TaRenameSlot addInstVarNamed: #renames
 ]

--- a/src/Talents-Pharo8/TaAbstractComposition.extension.st
+++ b/src/Talents-Pharo8/TaAbstractComposition.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #TaAbstractComposition }
+
+{ #category : #'*Talents-Pharo8' }
+TaAbstractComposition >> @@ anArrayOfAssociations [
+
+	"This operation creates a new trait composition element with a slot renamed.
+	The parameter is an array of association, where the key is the old name and the value the new name."
+	
+	^ TaRenameSlot rename: anArrayOfAssociations on: self
+]

--- a/src/Talents-Pharo8/TaRenameSlot.extension.st
+++ b/src/Talents-Pharo8/TaRenameSlot.extension.st
@@ -1,0 +1,58 @@
+Extension { #name : #TaRenameSlot }
+
+{ #category : #'*Talents-Pharo8' }
+TaRenameSlot >> copyTraitExpression [
+	^ self class rename: renames on: inner
+]
+
+{ #category : #'*Talents-Pharo8' }
+TaRenameSlot class >> rename: anArrayOfAssociations on: aTrait [
+	^ self new 
+		renames: anArrayOfAssociations;
+		inner: aTrait;
+		yourself.
+]
+
+{ #category : #'*Talents-Pharo8' }
+TaRenameSlot >> renames [
+
+	^ renames
+]
+
+{ #category : #'*Talents-Pharo8' }
+TaRenameSlot >> renames: anObject [
+
+	renames := anObject
+]
+
+{ #category : #'*Talents-Pharo8' }
+TaRenameSlot >> slots [
+
+	^ inner slots collect: [ :slot | 
+		  (renames asDictionary includesKey: slot name)
+			  ifTrue: [ 
+				  (TaRenamedSlotWrapper for: slot) name: (renames asDictionary at: slot name) ]
+			  ifFalse: [ slot ] ]
+]
+
+{ #category : #'*Talents-Pharo8' }
+TaRenameSlot >> sourceCodeAt: aSelector [
+	| originalSourceCode parseTree rewriter |
+	originalSourceCode := super sourceCodeAt: aSelector.
+
+	parseTree := RBParser parseMethod: originalSourceCode.
+	rewriter := RBParseTreeRewriter new.
+	
+	renames do: [:rename |
+		rewriter replace: rename key asString with: rename value asString ].
+	
+	^(rewriter	
+		executeTree: parseTree;
+		tree) formattedCode.
+]
+
+{ #category : #'*Talents-Pharo8' }
+TaRenameSlot >> traitCompositionExpression [
+	
+	^ self inner traitCompositionExpressionWithParens , ' @@ ' , renames printString
+]

--- a/src/Talents-Pharo8/TaRenamedSlotWrapper.class.st
+++ b/src/Talents-Pharo8/TaRenamedSlotWrapper.class.st
@@ -1,0 +1,81 @@
+"
+When renaming Slots in a trait composition, we want to give the trait a new name but else keep the orginal semantics.
+
+This wrapper does exactly that: as a Slot subclass, it has a name. It forwards anything else to the original slot as defined
+in the trait.
+"
+Class {
+	#name : #TaRenamedSlotWrapper,
+	#superclass : #Slot,
+	#instVars : [
+		'originalSlot'
+	],
+	#category : #'Talents-Pharo8'
+}
+
+{ #category : #'instance creation' }
+TaRenamedSlotWrapper class >> for: aSlot [
+	^self new originalSlot: aSlot
+]
+
+{ #category : #'code generation' }
+TaRenamedSlotWrapper >> emitStore: aMethodBuilder [
+	originalSlot emitStore: aMethodBuilder
+]
+
+{ #category : #'code generation' }
+TaRenamedSlotWrapper >> emitValue: aMethodBuilder [
+	originalSlot emitValue: aMethodBuilder
+]
+
+{ #category : #accessing }
+TaRenamedSlotWrapper >> index [
+	^ originalSlot index
+]
+
+{ #category : #accessing }
+TaRenamedSlotWrapper >> index: anInteger [
+	originalSlot index: anInteger
+]
+
+{ #category : #testing }
+TaRenamedSlotWrapper >> isVirtual [
+	^originalSlot isVirtual
+]
+
+{ #category : #testing }
+TaRenamedSlotWrapper >> isVisible [
+	^originalSlot isVisible
+]
+
+{ #category : #accessing }
+TaRenamedSlotWrapper >> originalSlot [
+
+	^ originalSlot
+]
+
+{ #category : #accessing }
+TaRenamedSlotWrapper >> originalSlot: anObject [
+
+	originalSlot := anObject
+]
+
+{ #category : #printing }
+TaRenamedSlotWrapper >> printOn: aStream [
+	originalSlot printOn: aStream
+]
+
+{ #category : #'meta-object-protocol' }
+TaRenamedSlotWrapper >> read: anObject [
+	^ originalSlot read: anObject
+]
+
+{ #category : #'meta-object-protocol' }
+TaRenamedSlotWrapper >> wantsInitialization [
+	^ originalSlot wantsInitialization
+]
+
+{ #category : #'meta-object-protocol' }
+TaRenamedSlotWrapper >> write: aValue to: anObject [
+	^ originalSlot write: aValue to: anObject
+]

--- a/src/Talents-Pharo8/package.st
+++ b/src/Talents-Pharo8/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Talents-Pharo8' }

--- a/src/Talents-Tests/TaAbstractTalentTest.class.st
+++ b/src/Talents-Tests/TaAbstractTalentTest.class.st
@@ -65,24 +65,24 @@ TaAbstractTalentTest >> setUp [
 			^ x = 0 ifTrue:[ 0 ] ifFalse:[ x + (self someRecursive: x - 1) ]
 	'.
 	
-	taTalentWithASlot := self newTalent: #TaTalentWithASlot with: {#anSlot => InstanceVariableSlot}.
+	taTalentWithASlot := self newTalent: #TaTalentWithASlot with: {#aSlot => InstanceVariableSlot}.
 	taTalentWithASlot compile: '
-		anSlot
-			^ anSlot.
+		aSlot
+			^ aSlot.
 	'.
 		taTalentWithASlot compile: '
-		anSlot: aValue
-			anSlot:=aValue.
+		aSlot: aValue
+			aSlot := aValue.
 	'.
 	
-	taTalentWithASlotInitialized := self newTalent: #TaTalentWithASlotInitiliazed with: #(anSlot).
+	taTalentWithASlotInitialized := self newTalent: #TaTalentWithASlotInitialized with: #(aSlot).
 	taTalentWithASlotInitialized compile: '
-		anSlot
-			^ anSlot.
+		aSlot
+			^ aSlot.
 	'.
 	taTalentWithASlotInitialized compile: '
 		initializeTalent
-			anSlot := 55.
+			aSlot := 55.
 	'.
 	
 	taAnotherInitializedSlot := self newTalent: #TaAnotherInitializedSlot with: #(anotherSlot).

--- a/src/Talents-Tests/TaArrayTest.class.st
+++ b/src/Talents-Tests/TaArrayTest.class.st
@@ -10,7 +10,7 @@ TaArrayTest >> testInitializeSlot [
 	x := {1. 2. 3}.
 	x addTalent: taTalentWithASlotInitialized.
 
-	self assert: x anSlot equals: 55.
+	self assert: x aSlot equals: 55.
 	self assert: (x at:1) equals: 1.
 	self assert: (x at:2) equals: 2.
 	self assert: (x at:3) equals: 3.		

--- a/src/Talents-Tests/TaTalentCompositionTest.class.st
+++ b/src/Talents-Tests/TaTalentCompositionTest.class.st
@@ -87,9 +87,9 @@ TaTalentCompositionTest >> testValidateDuplicateSlot [
 
 	x := Object new.
 
-	t1 := self newTalent:#T1 with: #(anSlot).
+	t1 := self newTalent:#T1 with: #(aSlot).
 
-	t2 := self newTalent:#T1 with: #(anSlot).
+	t2 := self newTalent:#T1 with: #(aSlot).
 	
 	self should:[x addTalent: t1 , t2] raise:Error.
 ]

--- a/src/Talents-Tests/TaTalentSlotsTests.class.st
+++ b/src/Talents-Tests/TaTalentSlotsTests.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #TaTalentSlotsTests,
 	#superclass : #TaAbstractTalentTest,
-	#category : 'Talents-Tests'
+	#category : #'Talents-Tests'
 }
 
 { #category : #tests }
@@ -10,7 +10,7 @@ TaTalentSlotsTests >> testInitializeSlot [
 	x := Object new.
 	x addTalent: taTalentWithASlotInitialized.
 
-	self assert: x anSlot equals: 55.
+	self assert: x aSlot equals: 55.
 ]
 
 { #category : #tests }
@@ -33,11 +33,11 @@ TaTalentSlotsTests >> testRenameKeepingOrderSlot [
 TaTalentSlotsTests >> testRenameSlot [
 	| x |
 	x := Object new.
-	x addTalent: taTalentWithASlotInitialized asTraitComposition >> (#anSlot -> #otherName).
+	x addTalent: taTalentWithASlotInitialized asTraitComposition >> (#aSlot -> #otherName).
 
-	self assert: x anSlot equals: 55.
+	self assert: x aSlot equals: 55.
 	self assert: (x instVarNamed: #otherName) equals: 55.
-	self should: [ x instVarAt: #anSlot ] raise: Error
+	self should: [ x instVarAt: #aSlot ] raise: Error
 ]
 
 { #category : #tests }
@@ -46,8 +46,8 @@ TaTalentSlotsTests >> testSimpleSlot [
 	x := Object new.
 	x addTalent: taTalentWithASlot.
 
-	x anSlot: 23.
-	self assert: x anSlot equals: 23.
+	x aSlot: 23.
+	self assert: x aSlot equals: 23.
 ]
 
 { #category : #tests }
@@ -56,6 +56,6 @@ TaTalentSlotsTests >> testTalentSequenceInitialization [
 	x := Object new.
 	x addTalent: taTalentWithASlotInitialized asTraitComposition + taAnotherInitializedSlot asTraitComposition.
 
-	self assert: x anSlot equals: 55.
+	self assert: x aSlot equals: 55.
 	self assert: x anotherSlot equals: 93.
 ]


### PR DESCRIPTION
Hi!

I've backported TaRenameSlot behavior from Pharo 9.0 by adding a conditional extension package and preload in the baseline. This should make all tests succeed in Pharo 8.0.

Hope you can integrate this!

Kind regards,
Jonathan